### PR TITLE
Minor tweaks for experimentation

### DIFF
--- a/notebook_utils.py
+++ b/notebook_utils.py
@@ -41,7 +41,6 @@ config = GPTConfig(**_model_config_dict)
 
 def _gen_experiment_name(model: nn.Module) -> str:
     backend_names = [b.__qualname__ for b in getattr(model, "backends", [])]
-    print(backend_names)
     if backend_names:
         us = any("unit_scaling" in b for b in backend_names)
         fp8 = any("quantisation" in b for b in backend_names)
@@ -73,7 +72,9 @@ def plot(df: pd.DataFrame) -> matplotlib.axes.Axes:
 
 
 def train(model: nn.Module, **config_overrides: Any) -> None:
-    experiment_name = _gen_experiment_name(model)
+    experiment_name = _gen_experiment_name(model) + config_overrides.pop(
+        "experiment_name_suffix", ""
+    )
 
     if not os.path.exists(f"{data_dir}/train.bin"):
         download_train_data()

--- a/train_ipu.py
+++ b/train_ipu.py
@@ -51,7 +51,7 @@ def run_training(
         **{**IPU_CONFIG_DEFAULTS, **config_dict}, model=model.config.__dict__
     )
     if cfg.wandb_log:
-        wandb.init(project=cfg.wandb_project, config=cfg.__dict__)
+        wandb.init(project=cfg.wandb_project, config=cfg.__dict__, reinit=True)
 
     if cfg.profile:
         profile = Path("profiles/latest")


### PR DESCRIPTION
Also note:

**Minimal quick train-only script**

```python
from notebook_utils import config, train
from nanoGPT.model import GPT
from unit_scaling.transforms import unit_scale

config.bias = False
model = unit_scale(GPT(config))
train(
    model,
    learning_rate=2**-5,
    min_lr=2**-5 / 10,
    eval_iters=0,
    experiment_name_suffix="",
)
```

**Patch for nanoGPT to allow `config.bias=False` on IPU**

```diff
diff --git a/model.py b/model.py
index c698f8b..463480a 100644
--- a/model.py
+++ b/model.py
@@ -20,11 +20,11 @@ class LayerNorm(nn.Module):
 
     def __init__(self, ndim, bias):
         super().__init__()
-        self.weight = nn.Parameter(torch.ones(ndim))
+        self.weight = nn.Parameter(torch.ones(ndim)) if bias else None
         self.bias = nn.Parameter(torch.zeros(ndim)) if bias else None
 
     def forward(self, input):
-        return F.layer_norm(input, self.weight.shape, self.weight, self.bias, 1e-5)
+        return F.layer_norm(input, (input.shape[-1],), self.weight, self.bias, 1e-5)
 
 class CausalSelfAttention(nn.Module):
```