### PR TITLE
Fix sequence length (block_size) in train_ipu.py

### DIFF
--- a/train_ipu.py
+++ b/train_ipu.py
@@ -81,8 +81,8 @@ def run_training(
     }
 
     def get_batch(split: str) -> Tuple[Tensor, Tensor]:
-        idx = torch.randint(len(data[split]) - cfg.block_size, (cfg.batch_size,))
-        tokens = torch.stack([data[split][i : i + cfg.block_size] for i in idx]).to(
+        idx = torch.randint(len(data[split]) - cfg.block_size - 1, (cfg.batch_size,))
+        tokens = torch.stack([data[split][i : i + cfg.block_size + 1] for i in idx]).to(
             torch.long
         )
         return tokens[:, :-1].contiguous(), tokens[:, 1:].contiguous()


### PR DESCRIPTION
Before this patch, `train_ipu.py` would use a sequence length of `cfg.block_size - 1`, whereas `train.py` would use `cfg.block_size`. This (predictably) doesn't change the results substantially, but it's worth removing any differences.