### PR TITLE
manually initialise optimizer._step_count

### DIFF
--- a/train_ipu.py
+++ b/train_ipu.py
@@ -155,7 +155,9 @@ def run_training(
             {"params": decay_params, "weight_decay": weight_decay},
             {"params": nodecay_params, "weight_decay": 0.0},
         ]
-        return poptorch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas)
+        optimizer = poptorch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas)
+        optimizer._step_count = 1
+        return optimizer
 
     def lr_schedule_fn(step: int) -> float:
         if step < cfg.warmup_iters:

--- a/train_ipu.py
+++ b/train_ipu.py
@@ -155,9 +155,7 @@ def run_training(
             {"params": decay_params, "weight_decay": weight_decay},
             {"params": nodecay_params, "weight_decay": 0.0},
         ]
-        optimizer = poptorch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas)
-        optimizer._step_count = 1
-        return optimizer
+        return poptorch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas)
 
     def lr_schedule_fn(step: int) -> float:
         if step < cfg.warmup_iters:
@@ -182,6 +180,7 @@ def run_training(
         model, cfg.weight_decay, cfg.learning_rate, betas=(cfg.beta1, cfg.beta2)
     )
     lr_schedule = torch.optim.lr_scheduler.LambdaLR(opt, lr_schedule_fn)
+    opt._step_count = 1
     trainer = poptorch.trainingModel(model, options=training_options, optimizer=opt)
     evaluator = poptorch.inferenceModel(model, options=inference_options)
 


### PR DESCRIPTION
 manually initiialise `optimizer._step_count` to prevent LRScheduler/Optimizer call order warning:

```
UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`. In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()`.  Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
```

Used elsewhere in graphcore/examples e.g., https://github.com/graphcore/examples/blob/master/multimodal/CLIP/pytorch/optimization.py#L18-L19